### PR TITLE
Add captureImage helper

### DIFF
--- a/main.js
+++ b/main.js
@@ -858,6 +858,12 @@ function populateLiverySelector(modelPath) {
     }
 }
 
+// Allow external scripts (e.g., Puppeteer) to capture the current canvas
+// as a PNG data URL.
+window.captureImage = function () {
+    return renderer.domElement.toDataURL('image/png');
+};
+
 
 // Initialize
 init();


### PR DESCRIPTION
## Summary
- allow external scripts to capture canvas image by adding `window.captureImage`

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_6867f1644fbc8331bf22e67a77a5bbdf