### PR TITLE
Add URL model/livery params

### DIFF
--- a/main.js
+++ b/main.js
@@ -136,6 +136,18 @@ function init() {
     loadSettingsCookies()
     console.log("done loading cookies")
 
+    const urlParams = new URLSearchParams(window.location.search);
+    if (urlParams.has('model')) {
+        curModelPath = urlParams.get('model');
+        modelSelector.value = curModelPath;
+        populateLiverySelector(curModelPath);
+    }
+    if (urlParams.has('livery')) {
+        currentLivery = urlParams.get('livery');
+        const liverySelector = document.getElementById('liverySelector');
+        liverySelector.value = currentLivery;
+    }
+
     setSkybox(scene, currentSkybox);
 
 


### PR DESCRIPTION
## Summary
- parse URL parameters for `model` and `livery`
- preset selectors and load the requested combination automatically

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_6867f142ed708331adfb3655fc5bedd4