### PR TITLE
Implement viewer ready event

### DIFF
--- a/main.js
+++ b/main.js
@@ -3,6 +3,8 @@ import { GLTFLoader } from 'three/addons/loaders/GLTFLoader.js';
 import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
 
 let firstRun = true
+// Flag that indicates when the viewer has finished loading a model
+window.viewerReady = false
 
 let scene, camera, renderer, model, prevModelPath, curModelPath, envMap, currentLivery
 
@@ -312,6 +314,8 @@ function setSkybox(scene, folderName) {
 
 
 function loadModel(modelPath) {
+    // Reset ready flag while we load a new model
+    window.viewerReady = false
     // Remove the existing model if it exists
     setCookie('model', modelPath)
 
@@ -346,7 +350,7 @@ function loadModel(modelPath) {
 
     let fullFilePath = `models/${modelPath}/${modelFiles[modelPath]}_Lod${LodLevel}.gltf`
 
-    loader.load(fullFilePath, (gltf) => {
+    loader.load(fullFilePath, async (gltf) => {
         model = gltf.scene;
         scene.add(model);
         // iterate through all materials and apply their texture from textures/*.png
@@ -429,7 +433,7 @@ function loadModel(modelPath) {
             prevModelPath = curModelPath
         }
         curModelPath = modelPath
-        mergeAndSetDecals()
+        await mergeAndSetDecals()
         applyMaterialPreset("baseLivery1", paintMaterials[bodyMaterials[0]])
         applyMaterialPreset("baseLivery2", paintMaterials[bodyMaterials[1]])
         applyMaterialPreset("baseLivery3", paintMaterials[bodyMaterials[2]])
@@ -577,6 +581,8 @@ async function mergeAndSetDecals() {
     } catch (error) {
         console.error(error);
     }
+    window.viewerReady = true
+    window.dispatchEvent(new Event('viewer-ready'))
 }
 
 function loadWheelModel(node, model, modelPath) {


### PR DESCRIPTION
## Summary
- expose `window.viewerReady` flag
- reset flag when loading a model
- set flag and dispatch `viewer-ready` at the end of decal merge

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_6867f14318e083318d8435c0c7d336f7