### PR TITLE
Disable UI when query parameters are present

### DIFF
--- a/main.js
+++ b/main.js
@@ -140,6 +140,16 @@ function init() {
 
     const urlParams = new URLSearchParams(window.location.search);
     const sideCamera = urlParams.has('sideCamera');
+    const hasQueryParams = Array.from(urlParams.keys()).length > 0;
+
+    if (hasQueryParams) {
+        ['settingsLayer', 'liveryLayer', 'overlay'].forEach(id => {
+            const element = document.getElementById(id);
+            if (element) {
+                element.style.display = 'none';
+            }
+        });
+    }
 
     if (urlParams.has('model')) {
         curModelPath = urlParams.get('model');


### PR DESCRIPTION
## Summary
- hide GUI elements if any query parameters exist in the URL

## Testing
- `npm --version`

------
https://chatgpt.com/codex/tasks/task_b_6867fa449a9483319b02950ef32c7ef3