### PR TITLE
Add shader overlay for decals

### DIFF
--- a/main.js
+++ b/main.js
@@ -54,7 +54,7 @@ function setupCarpaintMaterial(material) {
         shader.vertexShader = shader.vertexShader.replace('#include <uv_vertex>', '#include <uv_vertex>\n vUv2 = uv2;');
         let inject = `\nvarying vec2 vUv2;\nuniform sampler2D overlayMap1;\nuniform sampler2D overlayMap2;\nuniform sampler2D overlayMap3;\nuniform sampler2D decalMap;\nuniform sampler2D sponsorMap;\nuniform vec3 overlayColor1;\nuniform vec3 overlayColor2;\nuniform vec3 overlayColor3;\n`;
         shader.fragmentShader = inject + shader.fragmentShader;
-        shader.fragmentShader = shader.fragmentShader.replace('#include <map_fragment>', `\n#ifdef USE_MAP\n    vec4 baseCol = texture2D(map, vUv);\n#else\n    vec4 baseCol = vec4(1.0);\n#endif\n    vec4 overlayCol = vec4(1.0);\n    overlayCol *= texture2D(overlayMap1, vUv2) * vec4(overlayColor1,1.0);\n    overlayCol *= texture2D(overlayMap2, vUv2) * vec4(overlayColor2,1.0);\n    overlayCol *= texture2D(overlayMap3, vUv2) * vec4(overlayColor3,1.0);\n    overlayCol *= texture2D(decalMap, vUv2);\n    overlayCol *= texture2D(sponsorMap, vUv2);\n    diffuseColor *= baseCol * overlayCol;\n`);
+        shader.fragmentShader = shader.fragmentShader.replace('#include <map_fragment>', `\n#ifdef USE_MAP\n    vec4 baseCol = texture2D(map, vMapUv);\n#else\n    vec4 baseCol = vec4(1.0);\n#endif\n    vec4 overlayCol = vec4(1.0);\n    overlayCol *= texture2D(overlayMap1, vUv2) * vec4(overlayColor1,1.0);\n    overlayCol *= texture2D(overlayMap2, vUv2) * vec4(overlayColor2,1.0);\n    overlayCol *= texture2D(overlayMap3, vUv2) * vec4(overlayColor3,1.0);\n    overlayCol *= texture2D(decalMap, vUv2);\n    overlayCol *= texture2D(sponsorMap, vUv2);\n    diffuseColor *= baseCol * overlayCol;\n`);
     };
     material.needsUpdate = true;
 }

--- a/main.js
+++ b/main.js
@@ -79,7 +79,7 @@ uniform vec3 overlayColor3;
     finalCol.rgb = mix(finalCol.rgb, overlayColor3, mask3);
     finalCol *= texture2D(decalMap, vMapUv);
     finalCol *= texture2D(sponsorMap, vMapUv);
-    diffuseColor *= finalCol;
+    diffuseColor = finalCol;
 `;
 
         shader.fragmentShader = shader.fragmentShader.replace(

--- a/main.js
+++ b/main.js
@@ -51,16 +51,20 @@ function setupCarpaintMaterial(material) {
         shader.uniforms.overlayColor1 = material.userData.overlayUniforms.overlayColor1;
         shader.uniforms.overlayColor2 = material.userData.overlayUniforms.overlayColor2;
         shader.uniforms.overlayColor3 = material.userData.overlayUniforms.overlayColor3;
-        let inject = `\n` +
-            `uniform sampler2D overlayMap1;\n` +
-            `uniform sampler2D overlayMap2;\n` +
-            `uniform sampler2D overlayMap3;\n` +
-            `uniform sampler2D decalMap;\n` +
-            `uniform sampler2D sponsorMap;\n` +
-            `uniform vec3 overlayColor1;\n` +
-            `uniform vec3 overlayColor2;\n` +
-            `uniform vec3 overlayColor3;\n`;
-        shader.fragmentShader = inject + shader.fragmentShader;
+
+        const uniformDecl = `
+uniform sampler2D overlayMap1;
+uniform sampler2D overlayMap2;
+uniform sampler2D overlayMap3;
+uniform sampler2D decalMap;
+uniform sampler2D sponsorMap;
+uniform vec3 overlayColor1;
+uniform vec3 overlayColor2;
+uniform vec3 overlayColor3;
+`;
+        shader.fragmentShader = uniformDecl + shader.fragmentShader;
+
+        const mixFrag = `
 #ifdef USE_MAP
     vec4 baseCol = texture2D(map, vMapUv);
 #else
@@ -75,7 +79,12 @@ function setupCarpaintMaterial(material) {
     finalCol.rgb = mix(finalCol.rgb, overlayColor3, mask3);
     finalCol *= texture2D(decalMap, vMapUv);
     finalCol *= texture2D(sponsorMap, vMapUv);
-    diffuseColor *= finalCol;`
+    diffuseColor *= finalCol;
+`;
+
+        shader.fragmentShader = shader.fragmentShader.replace(
+            '#include <output_fragment>',
+            `${mixFrag}\n#include <output_fragment>`
         );
     };
     material.needsUpdate = true;


### PR DESCRIPTION
## Summary
- overlay textures with UV2 using shader instead of extra meshes
- integrate custom carpaint shader and update material presets
- reset overlay textures when loading models

## Testing
- `node --version`

------
https://chatgpt.com/codex/tasks/task_b_68681632e3f48331b84330661d582b24